### PR TITLE
enable fd_readdir for android target

### DIFF
--- a/src/uvwasi.c
+++ b/src/uvwasi.c
@@ -15,7 +15,7 @@
 
 #define UVWASI__READDIR_NUM_ENTRIES 1
 
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if !defined(_WIN32)
 # define UVWASI_FD_READDIR_SUPPORTED 1
 #endif
 

--- a/test/test-ebadf-input-validation.c
+++ b/test/test-ebadf-input-validation.c
@@ -46,12 +46,12 @@ int main(void) {
   CHECK(uvwasi_fd_prestat_dir_name(&uvw, 100, test_str, 10));
   CHECK(uvwasi_fd_pwrite(&uvw, 100, &test_ciovec, 2, 10, &test_size));
   CHECK(uvwasi_fd_read(&uvw, 100, &test_iovec, 2, &test_size));
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if !defined(_WIN32)
   CHECK(uvwasi_fd_readdir(&uvw, 100, test_void, 3, test_dircookie, &test_size));
 #else
   assert(UVWASI_ENOSYS ==
       uvwasi_fd_readdir(&uvw, 100, test_void, 3, test_dircookie, &test_size));
-#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+#endif /* !defined(_WIN32) */
   CHECK(uvwasi_fd_renumber(&uvw, 100, 2));
   CHECK(uvwasi_fd_seek(&uvw, 100, 10, UVWASI_WHENCE_CUR, &test_filesize));
   CHECK(uvwasi_fd_sync(&uvw, 100));

--- a/test/test-fd-advise-dir.c
+++ b/test/test-fd-advise-dir.c
@@ -9,7 +9,7 @@
 #define TEST_PATH_ADVISE TEST_TMP_DIR "/test_fd_advise_dir"
 
 int main(void) {
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if !defined(_WIN32)
   uvwasi_t uvwasi;
   uvwasi_options_t init_options;
   uv_fs_t req;
@@ -40,6 +40,6 @@ int main(void) {
 
   uvwasi_destroy(&uvwasi);
   free(init_options.preopens);
-#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+#endif /* !defined(_WIN32) */
   return 0;
 }

--- a/test/test-fd-readdir-cookie.c
+++ b/test/test-fd-readdir-cookie.c
@@ -10,7 +10,7 @@
 #define TEST_TMP_DIR "./out/tmp"
 #define TEST_PATH_READDIR TEST_TMP_DIR "/test_readdir_cookie"
 
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if !defined(_WIN32)
 static void touch_file(const char *name) {
   uv_fs_t req;
   int r;
@@ -23,14 +23,14 @@ static void touch_file(const char *name) {
   uv_fs_req_cleanup(&req);
   assert(r == 0);
 }
-#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+#endif /* !defined(_WIN32) */
 
 /*
  * This is a test case for https://github.com/nodejs/node/issues/47193.
  */
 
 int main(void) {
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if !defined(_WIN32)
   uvwasi_t uvwasi;
   uvwasi_options_t init_options;
   uvwasi_dircookie_t cookie;
@@ -96,6 +96,6 @@ int main(void) {
   uvwasi_destroy(&uvwasi);
   free(init_options.preopens);
 
-#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+#endif /* !defined(_WIN32) */
   return 0;
 }

--- a/test/test-fd-readdir-ls.c
+++ b/test/test-fd-readdir-ls.c
@@ -10,7 +10,7 @@
 #define TEST_PATH_READDIR TEST_TMP_DIR "/test_readdir_ls"
 
 
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if !defined(_WIN32)
 static void touch_file(const char* name) {
   uv_fs_t req;
   int r;
@@ -27,14 +27,14 @@ static void touch_file(const char* name) {
   uv_fs_req_cleanup(&req);
   assert(r == 0);
 }
-#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+#endif /* !defined(_WIN32) */
 
 /*
  * This is a test case for https://github.com/nodejs/uvwasi/issues/174.
  */
 
 int main(void) {
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if !defined(_WIN32)
   uvwasi_t uvwasi;
   uvwasi_options_t init_options;
   uvwasi_dircookie_t cookie;
@@ -85,6 +85,6 @@ int main(void) {
   uvwasi_destroy(&uvwasi);
   free(init_options.preopens);
 
-#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+#endif /* !defined(_WIN32) */
   return 0;
 }

--- a/test/test-fd-readdir.c
+++ b/test/test-fd-readdir.c
@@ -12,7 +12,7 @@
 #define TEST_PATH_FILE_2 TEST_PATH_READDIR "/test_file_2"
 
 
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if !defined(_WIN32)
 static void touch_file(const char* name) {
   uv_fs_t req;
   int r;
@@ -29,11 +29,11 @@ static void touch_file(const char* name) {
   uv_fs_req_cleanup(&req);
   assert(r == 0);
 }
-#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+#endif /* !defined(_WIN32) */
 
 
 int main(void) {
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if !defined(_WIN32)
   uvwasi_t uvwasi;
   uvwasi_options_t init_options;
   uvwasi_dircookie_t cookie;
@@ -113,6 +113,6 @@ int main(void) {
 
   uvwasi_destroy(&uvwasi);
   free(init_options.preopens);
-#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+#endif /* !defined(_WIN32) */
   return 0;
 }

--- a/test/test-fstflags-validate.c
+++ b/test/test-fstflags-validate.c
@@ -8,7 +8,7 @@
 #define TEST_TMP_DIR "./out/tmp"
 
 int main(void) {
-#if !defined(_WIN32) && !defined(__ANDROID__)
+#if !defined(_WIN32)
   uvwasi_t uvwasi;
   uvwasi_options_t init_options;
   uvwasi_errno_t err;
@@ -42,6 +42,6 @@ int main(void) {
 
   uvwasi_destroy(&uvwasi);
   free(init_options.preopens);
-#endif /* !defined(_WIN32) && !defined(__ANDROID__) */
+#endif /* !defined(_WIN32) */
   return 0;
 }


### PR DESCRIPTION
This was disabled in 7523499546c351a1642442e6ec7bd32bcac76e2c for Android. Current implementation doesn't rely at all on any of the platform specific APIs, but uses libuv, so should be fine to enable

Tested on Android using Termux. All tests green for debug builds.

Somehow is needed to be needed to fix test failures for `test-wasi-pthread`. Original source of patch: github.com/termux/termux-packages/commit/2f3e1399de80b6416e1c8564248e6c1beeb91ea2